### PR TITLE
Enable SELinux and don't mount /srv when not in 'vagrant' mode.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,8 +33,12 @@ Vagrant.configure(2) do |config|
 
   ### Application Specific Setup #########
 
-  # mount the /srv folder with the right permissions
-  config.vm.synced_folder "./srv/", "/srv/"
+  # unless we're not in vagrant mode, mount the /srv folder so that we
+  # can remount it with the right permissions later
+
+  unless myvars.key?("environment_name") && "vagrant" != myvars["environment_name"]
+    config.vm.synced_folder "./srv/", "/srv/"
+  end
   
   # Temorary workaround because Windows
   config.vm.provision "shell", path: "bootstrap.sh"

--- a/my-vars.default.yml
+++ b/my-vars.default.yml
@@ -36,3 +36,6 @@ local_dn_suffix: 'drupal.vm.test'
 
 # Passing the local domain on to apache
 httpd_dn_suffix: "{{ local_dn_suffix }}"
+
+# What style of environment to build: vagrant, test or prod
+environment_name: "vagrant"

--- a/my-vars.default.yml
+++ b/my-vars.default.yml
@@ -37,5 +37,5 @@ local_dn_suffix: 'drupal.vm.test'
 # Passing the local domain on to apache
 httpd_dn_suffix: "{{ local_dn_suffix }}"
 
-# What style of environment to build: vagrant, test or prod
+# Style of environment to build: vagrant, test or prod
 environment_name: "vagrant"

--- a/vagrant-post-tasks.yml
+++ b/vagrant-post-tasks.yml
@@ -7,6 +7,7 @@
   register: apache_group
 - name: Unmount /srv
   mount: name=/srv fstype=vboxsf src=srv  state=unmounted
+  when: environment_name == "vagrant"
 - name: Mount srv to /srv with the right permissions
   mount:
     name: /srv
@@ -14,3 +15,4 @@
     src: srv
     opts: "uid={{apache_user.stdout}},gid={{apache_group.stdout}},dmode=775,fmode=664"
     state: mounted
+  when: environment_name == "vagrant"

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -13,8 +13,16 @@
     - OULibraries.ngrok
 
   tasks:
-    - name: Disable selinux for vagrant
-      selinux: state=disabled
+    - name: Enable selinux for testing
+      selinux:
+        state: enforcing
+        policy: targeted
+      when: environment_name != "vagrant"
+    - name: Disable selinux for vagrant dev
+      selinux:
+        state: disabled
+      when: environment_name == "vagrant"
+
     - name: Add apache user to vagrant group
       user:
         name: apache


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

This PR adjusts the vagrant environment to use the pre-existing `environment_name` variable to disable developer conveniences. 

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
## Motivation and Context

We need to be able to switch on SELinux and real Linux file system permissions for more realistic testing.  Closes #16.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
- vagrant up with environment_name = 'vagrant'
- vagrant up with environment_name = 'prod'
