### PR TITLE
Require latest ansible-role-d7.

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -9,7 +9,7 @@
   name: OULibraries.mariadb
 
 - src: https://github.com/OULibraries/ansible-role-d7
-  version: origin/dev-removedb
+  version: v2016-04-15.0
   name: OULibraries.d7
 
 - src: https://github.com/OULibraries/ansible-role-ngrok


### PR DESCRIPTION
Moves ansible-role-d7 requirement to v2016-04-15.0
## Motivation and Context

Closes #15 and updates us to latest tagged version of our d7 code. 
## How Has This Been Tested?

`ansible-galaxy install -r requirements.yml -p ./roles --force`
