### PR TITLE
install dependencies completely via git

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,11 @@
 - src: https://github.com/OULibraries/ansible-role-centos7
   version: v2016-04-08.0
   name: OULibraries.centos7
-
+  
+- src: https://github.com/OULibraries/ansible-role-apache2
+  version: v2016-04-08.0
+  name: OULibraries.apache2
+  
 - src: https://github.com/OULibraries/ansible-role-mariadb
   version: v2016-04-08.0
   name: OULibraries.mariadb


### PR DESCRIPTION
removing roles from galaxy broke some of our dependency resolution, as we were half-relying on galaxy and half relying on git.
## Motivation and Context

we need vagrant up and ec2 init to work
https://github.com/OULibraries/vagrant_d7/issues/23
## How Has This Been Tested?

I updated my dependencies locally and was then able to vagrant up.
