### PR TITLE
Use new CentOS 7 Role

### DIFF
--- a/my-vars.default.yml
+++ b/my-vars.default.yml
@@ -26,11 +26,15 @@ tunnels:
     port: '443'
     proto: 'tls'
 
-# Local passwords
-mariadb_root_pass: 'root'
+# Local credentials
+# additional shell accounts
+users:
+  - name: 'libacct'
+    groups: 'wheel'
+    pubkey: 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAtkaGGkonm3HJmRoupKgM0A04uZu3aPhFyWmyMWCHTk1TtDskTgO0krOgUKuxAB2G/d39Xz6oISL9+dQdZt5aEJK7WoHpkK8l8xXfrIJ8OiWuJ+IRygjjLsib8tVTRsEIvMrQUtnhGzVNM7lQNXaEviGmR+ZunH68fv/QpomR5qW/veLFsR0KQLnd8yoG2+Tm8EdYouDcUPTS1nr9XdPSWGcsvpDq48JdxSmtXXC/8NHfdhpmCMmoC/IXbFl7typeLd9gt7EFvqOLWEbysEF3hD6hMAV3MEWaDnhf25n2cUgdAvdk086REgg2bXx1dBdeSi+wq5MadfP80UuPuaN2lw== libacct@ou.edu'
 
-# crypt value of 'libacct' because ansible
-user_pass: '$6$rounds=100000$qrlkLzoJAmDl4q46$8lUP.o5oe8Cmr/OCy8/pdIvbuSP8KaC8cqVHvmsMzObotRakn2lSMEnu/z0bI4NbXJ4zPoQ.8yUWvw2SqveDJ1'
+# root db password
+mariadb_root_pass: 'root'
 
 # Passing the local domain on to apache
 httpd_dn_suffix: "ngrok.io"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 
 - src: https://github.com/OULibraries/ansible-role-centos7
-  version: v2016-04-08.0
+  version: v2016-04-15.0
   name: OULibraries.centos7
   
 - src: https://github.com/OULibraries/ansible-role-apache2

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 
 - src: https://github.com/OULibraries/ansible-role-centos7
-  version: v2016-04-15.0
+  version: v2016-04-15.1
   name: OULibraries.centos7
   
 - src: https://github.com/OULibraries/ansible-role-apache2


### PR DESCRIPTION
The new CentOS 7 role handles users a bit differently, so we need to make a few changes.
## Motivation and Context

Keeping dev as prod-like as is feasible.
## How Has This Been Tested?

vagrant up
d7_init.sh
browse site
