### PR TITLE
Make sure playbook variables are where our roles expect to find them.

### DIFF
--- a/vagrant.yml
+++ b/vagrant.yml
@@ -1,11 +1,12 @@
 ---
-- hosts: default
+- hosts: localhost
   sudo: yes
   vars_files:
     - my-vars.yml
   pre_tasks:
     - name: /srv is a directory
       file: path=/srv state=directory mode=0755 force=yes
+
   roles:
     - OULibraries.centos7
     - OULibraries.mariadb
@@ -33,3 +34,7 @@
         name: vagrant
         append: yes
         groups: apache
+
+
+
+        

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -7,6 +7,11 @@
     - name: /srv is a directory
       file: path=/srv state=directory mode=0755 force=yes
 
+    - name: Check preconditions for running playbook. 
+      assert:
+        that:
+          - mariadb_root_pass is defined
+
   roles:
     - OULibraries.centos7
     - OULibraries.mariadb


### PR DESCRIPTION
This PR switches the context of this playbook from `default` to `localhost` and adds a precondition check to make sure that an admin password for mariadb is defined. 
## Motivation and Context

Mainly straightens out some confusion about variables that mostly lived in @lo5an's brain, but also completes the switch to an Ansible local style playbook. 
## How Has This Been Tested?

Successful vagrant up with variables defined, unsuccessful vagrant up without. 
