### PR TITLE
Add support for new users role to requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,10 +1,10 @@
 ---
 - src: https://github.com/OULibraries/ansible-role-centos7
-  version: v2016-04-18.1
+  version: v2016-04-25.0
   name: OULibraries.centos7
 
 - src: https://github.com/OULibraries/ansible-role-apache2
-  version: v2016-04-18.0
+  version: v2016-04-25.0
   name: OULibraries.apache2
 
 - src: https://github.com/OULibraries/ansible-role-mariadb
@@ -12,9 +12,13 @@
   name: OULibraries.mariadb
 
 - src: https://github.com/OULibraries/ansible-role-d7
-  version: v2016-04-22.0
+  version: v2016-04-15.0
   name: OULibraries.d7
 
 - src: https://github.com/OULibraries/ansible-role-ngrok
   version: v2016-04-08.0
   name: OULibraries.ngrok
+
+- src: https://github.com/OULibraries/ansible-role-users
+  version: v2016-04-25.0
+  name: OULibraries.users

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -11,7 +11,7 @@
     - OULibraries.mariadb
     - OULibraries.d7
     - OULibraries.ngrok
-
+    - OULibraries.users
   tasks:
     - name: Enable selinux for testing
       selinux:


### PR DESCRIPTION
Changes out installed and applied roles to take advantage of our new user handling
## Motivation and Context

This a prerequisite to make syncing to/from remote systems work happily.
## How Has This Been Tested?

vagrant up
d7_init.sh
