### PR TITLE
Preserve shell colors while provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure(2) do |config|
   end
   
   # Temorary workaround because Windows
-  config.vm.provision "shell", path: "bootstrap.sh"
+  config.vm.provision "shell", path: "bootstrap.sh", keep_color: "True"
 
     
   # # Then do d7 stuff

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Keep colors intact
+export PYTHONUNBUFFERED=1
+export ANSIBLE_FORCE_COLOR=1
+
 # we need git and ansible to get started
 yum install -y git
 yum install -y ansible


### PR DESCRIPTION
Updated Vagrantfile and bootstrap.sh to pass color-coded ansible output to the terminal on the host machine.
## Motivation and Context

I was getting really annoyed trying to debug a new playbook without the color cues provided by ansible.
## How Has This Been Tested?

vagrant up, vagrant provision on linux host
