### PR TITLE
Use SELinux Permissive mode for vagrant.

### DIFF
--- a/vagrant.yml
+++ b/vagrant.yml
@@ -20,7 +20,7 @@
       when: environment_name != "vagrant"
     - name: Disable selinux for vagrant dev
       selinux:
-        state: disabled
+        state: permissive
       when: environment_name == "vagrant"
 
     - name: Add apache user to vagrant group


### PR DESCRIPTION
## Motivation and Context

Disabling selinux breaks the build scripts. 
## How Has This Been Tested?

install+make+sync
